### PR TITLE
Remove waffle.io link for Trello

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
                     <a href="https://github.com/DataHaskell">
                         <img src="https://img.shields.io/github/followers/datahaskell.svg?style=social&label=Follow" alt="">
                     </a>
-                    <a href="http://waffle.io/DataHaskell/OrganizationTasks">
-                        <img src="https://badge.waffle.io/DataHaskell/OrganizationTasks.svg?label=ready&title=Pending tasks" alt="waffle">
+                    <a href="https://trello.com/b/ucB25d5v/tasks">
+                        Trello
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
Link to the Trello board which is up-to-date.